### PR TITLE
Update Makefile for figures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,11 +23,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
-      
+        
     - name: Build the document
-      run: 
-        make update  # this pulls in the current ivoatex
-        make update-ci
+      run: make
       
     - name: Check the output
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,9 @@ jobs:
         sudo apt install texlive-latex-base texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended xsltproc latexmk cm-super
       
     - name: Build the document
-      run: make
+      run: 
+        make update  # this pulls in the current ivoatex
+        make update-ci
       
     - name: Check the output
       run: |

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SOURCES = $(DOCNAME).tex role_diagram.pdf Appendix.tex
 FIGURES = role_diagram.pdf
 
 # List of PDF figures (for vector graphics)
-VECTORFIGURES = 
+VECTORFIGURES = role_diagram.svg
 
 # Additional files to distribute (e.g., CSS, schema files, examples...)
 AUX_FILES =

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ IVOA_GROUP = Data Model
 SOURCES = $(DOCNAME).tex role_diagram.pdf Appendix.tex
 
 # List of pixel image files to be included in submitted package
-FIGURES = role_diagram.svg
+FIGURES = role_diagram.pdf
 
 # List of PDF figures (for vector graphics)
-VECTORFIGURES = role_diagram.pdf
+VECTORFIGURES = 
 
 # Additional files to distribute (e.g., CSS, schema files, examples...)
 AUX_FILES =


### PR DESCRIPTION
pb in regenerating figures role_diagram.pdf from role_diagram.svg  error : 
PDF fallback: A conversion from SVG to PDF failed. This is probably because inkscape is not installed. While SVG is not supported by the major TeX engines, it is recommended to commit built PDFs to the VCS.